### PR TITLE
Issue #19: Fix the error on the settings menu.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,7 +16,7 @@
                 "caption": "Settings",
                 "command": "edit_settings",
                 "args": {
-                  "base_file": "${packages}/carbonSublime/carbonSublime.sublime-settings",
+                  "base_file": "${packages}/Carbon/carbonSublime.sublime-settings",
                   "default": "{\n\t$0\n}\n"
                 }
               }


### PR DESCRIPTION
Fixes #19 . The issue is caused since the package name recognized by Package Control is `Carbon` not `carbonSublime`.